### PR TITLE
SLING-10852 - Upgrade ESAPI to 2.2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>org.owasp.esapi</groupId>
             <artifactId>esapi</artifactId>
-            <version>2.2.1.1</version>
+            <version>2.2.3.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
SLING-10852  Upgrade  OWASP ESAPI Java library to 2.2.3.0 to remove vulnerability XML External Entity (XXE) Injection