### PR TITLE
SLING-10953 - Update dependency Antisamy version from 1.5.10 to 1.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <dependency>
             <groupId>org.owasp.antisamy</groupId>
             <artifactId>antisamy</artifactId>
-            <version>1.5.10</version>
+            <version>1.6.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/xss/impl/AttributeTranslatingTransformerFactoryImpl.java
+++ b/src/main/java/org/apache/sling/xss/impl/AttributeTranslatingTransformerFactoryImpl.java
@@ -1,0 +1,55 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.xss.impl;
+
+import static javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD;
+import static javax.xml.XMLConstants.ACCESS_EXTERNAL_STYLESHEET;
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.TransformerConfigurationException;
+
+import org.apache.xalan.processor.TransformerFactoryImpl;
+
+/**
+ * Translates configuration calls to specific unsupported attributes to the {@link XMLConstants#FEATURE_SECURE_PROCESSING} feature
+ *
+ * <p>This is done in order to support AntiSamy 1.6.4 which requires the usage of a JAXP 1.5 compliant
+ * transformer factory, which is Xalan is not. This implementation is minimal and not expected to be used
+ * outside of this bundle.</p>
+ *
+ * @see <a href="https://github.com/nahsra/antisamy/issues/103">AntiSamy issue 103</a>
+ */
+public class AttributeTranslatingTransformerFactoryImpl extends TransformerFactoryImpl {
+
+    @Override
+    public void setAttribute(String name, Object value) throws IllegalArgumentException {
+        if ( "".equals(value) &&  (
+                ACCESS_EXTERNAL_DTD.equals(name) ||
+                ACCESS_EXTERNAL_STYLESHEET.equals(name) ) ) {
+            try {
+                setFeature(FEATURE_SECURE_PROCESSING, true);
+                return;
+            } catch (TransformerConfigurationException e) {
+                throw new IllegalArgumentException("Failed translating attribute " + name + " top feature " + FEATURE_SECURE_PROCESSING ,e);
+            }
+        }
+        super.setAttribute(name, value);
+    }
+}

--- a/src/main/java/org/apache/sling/xss/impl/AttributeTranslatingTransformerFactoryImpl.java
+++ b/src/main/java/org/apache/sling/xss/impl/AttributeTranslatingTransformerFactoryImpl.java
@@ -47,7 +47,7 @@ public class AttributeTranslatingTransformerFactoryImpl extends TransformerFacto
                 setFeature(FEATURE_SECURE_PROCESSING, true);
                 return;
             } catch (TransformerConfigurationException e) {
-                throw new IllegalArgumentException("Failed translating attribute " + name + " top feature " + FEATURE_SECURE_PROCESSING ,e);
+                throw new IllegalArgumentException("Failed translating attribute " + name + " to feature " + FEATURE_SECURE_PROCESSING ,e);
             }
         }
         super.setAttribute(name, value);

--- a/src/main/java/org/apache/sling/xss/impl/FallbackSlingPolicy.java
+++ b/src/main/java/org/apache/sling/xss/impl/FallbackSlingPolicy.java
@@ -31,7 +31,7 @@ public class FallbackSlingPolicy extends InternalPolicy {
     private final Object aTagLock = new Object();
 
     public FallbackSlingPolicy(InputStream inputStream) throws PolicyException {
-       super(null, getSimpleParseContext(getTopLevelElement(new InputSource(inputStream))));
+       super(getSimpleParseContext(getTopLevelElement(new InputSource(inputStream), () -> new InputSource(inputStream))));
 
     }
 

--- a/src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory
+++ b/src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+org.apache.sling.xss.impl.AttributeTranslatingTransformerFactoryImpl


### PR DESCRIPTION
Update and fix compiler errors. Tests currently fail due to xalan not supporting
the 'accessExternalDTD' and 'accessExternalStylesheet' attributes.