### PR TITLE
SLING-10953 - Update dependency Antisamy version from 1.5.10 to 1.6.4

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -28,7 +28,10 @@ Import-Package: !bsh, \
 Private-Package: org.apache.sling.xss.impl, \
                  org.apache.batik.*, \
                  org.w3c.css.sac, \
+                 org.apache.xalan.*, \
                  org.apache.xerces.*, \
+                 org.apache.xml.*, \
+                 org.apache.xpath.*, \
                  org.apache.xml.serialize, \
                  org.apache.xml.serializer.*, \
                  org.apache.commons.beanutils.*;-split-package:=merge-first, \
@@ -36,5 +39,6 @@ Private-Package: org.apache.sling.xss.impl, \
                  org.apache.commons.logging.impl, \
                  org.cyberneko.html.*, \
                  org.owasp.*, \
+                 java_cup.runtime, \
                  javax.xml.parsers;-split-package:=merge-first, \
                  javax.xml.transform;-split-package:=merge-first


### PR DESCRIPTION
Teach the embedded javax.xml.transform.FactoryFinder to load classes using the ServiceLoader mechanism. Otherwise our customer FactoryFinder is not used in OSGi environments.