### PR TITLE
Replace commons-io version 2.6 with 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.11.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Replace commons-io version 2.6 with version 2.11 to mitigate the following security vulnerabilities:

[CVE - CVE-2021-29425 (mitre.org)](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29425)
[CVE - CVE-2020-15250 (mitre.org)](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)

JIRA : [SLING-11202](https://issues.apache.org/jira/browse/SLING-11202)