### PR TITLE
SLING-12118 - Update batik-css to version 1.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-css</artifactId>
-            <version>1.14</version>
+            <version>1.17</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
[SLING-12118](https://issues.apache.org/jira/browse/SLING-12118)
[CVE-2022-44729](https://www.cvedetails.com/cve/CVE-2022-44729/)