### PR TITLE
SLING-12137 - XSS API bundle no longer embeds the needed org.owasp.html classes

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -45,4 +45,5 @@ Private-Package: org.apache.sling.xss.impl, \
                  org.apache.commons.configuration.*, \
                  org.apache.commons.logging.impl, \
                  org.owasp.esapi.*;-split-package:=merge-first, \
-                 org.owasp.validator.*
+                 org.owasp.validator.*, \
+                 org.owasp.html.*;-split-package:=merge-first


### PR DESCRIPTION
Mark org.owasp.html as a private-package so that it is included in the jar file. Use 'merge-first' since we provide classes in our own project. We don't overwrite anything, but this is the more desireable outcome.