### PR TITLE
SLING-12388 remove duplicate literals

### DIFF
--- a/src/main/java/org/apache/sling/xss/impl/xml/Attribute.java
+++ b/src/main/java/org/apache/sling/xss/impl/xml/Attribute.java
@@ -85,6 +85,7 @@ public class Attribute {
         return getLiteralList().stream()
                 .map(Literal::getValue)
                 .map(String::toLowerCase)
+                .distinct()
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
The [previous version ](https://github.com/OWASP/java-html-sanitizer/blob/e35ef4fec8a4021845204c5cedb952e1aaf679e4/src/main/java/org/owasp/html/HtmlPolicyBuilder.java#L943)of the embedded html-sanitizer used Guava's ``ImmutableSet.copyOf(...)`` method to create the set, and this method removes any duplicates. The native Java 9+ ``Set.of(...)`` does not do that (throws an exception instead), and for that reason we need to. remove any duplicates ourselves.